### PR TITLE
Updating packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"author": "Mike Kornelson <mike@durbn.net>",
 	"license": "MIT",
 	"devDependencies": {
-		"babel-core": "^6.24.1",
+		"babel-core": "^6.25.0",
 		"babel-loader": "^7.0.0",
 		"babel-preset-es2015": "^6.24.1",
 		"babel-preset-react": "^6.24.1",
@@ -33,16 +33,16 @@
 		"jsdoc-babel": "^0.3.0",
 		"jsdom": "^9.0.0",
 		"mocha": "^3.4.2",
-		"react": "^15.5.4",
-		"react-addons-test-utils": "^15.5.1",
-		"react-dom": "^15.5.4",
-		"react-test-renderer": "^15.5.4",
+		"react": "^15.6.1",
+		"react-addons-test-utils": "^15.6.0",
+		"react-dom": "^15.6.1",
+		"react-test-renderer": "^15.6.1",
 		"sinon": "^2.3.4",
-		"webpack": "^2.4.1",
-		"webpack-node-externals": "^1.5.4"
+		"webpack": "^3.0.0",
+		"webpack-node-externals": "^1.6.0"
 	},
 	"dependencies": {
 		"lodash": "^4.17.4",
-		"prop-types": "^15.5.8"
+		"prop-types": "^15.5.10"
 	}
 }


### PR DESCRIPTION
webpack  ^2.4.1  →  ^3.0.0 
 prop-types               ^15.5.8  →  ^15.5.10 
 babel-core               ^6.24.1  →   ^6.25.0 
 react                    ^15.5.4  →   ^15.6.1 
 react-addons-test-utils  ^15.5.1  →   ^15.6.0 
 react-dom                ^15.5.4  →   ^15.6.1 
 react-test-renderer      ^15.5.4  →   ^15.6.1 
 webpack-node-externals    ^1.5.4  →    ^1.6.0